### PR TITLE
fix: add support for `CLAMD_DISABLE_CONCURRENT_RELOAD`

### DIFF
--- a/config/clamd.conf.erb
+++ b/config/clamd.conf.erb
@@ -1,7 +1,10 @@
-DatabaseDirectory <%= ENV['CLAMD_DATABASE_DIR'] %>
-LocalSocket       <%= ENV['CLAMD_LOCAL_SOCKET'] %>
-FixStaleSocket    yes
-LogTime           yes
-LogVerbose        yes
-Debug             no
-Foreground        no
+DatabaseDirectory         <%= ENV['CLAMD_DATABASE_DIR'] %>
+LocalSocket               <%= ENV['CLAMD_LOCAL_SOCKET'] %>
+FixStaleSocket            yes
+LogTime                   yes
+LogVerbose                yes
+Debug                     no
+Foreground                no
+<% if !ENV['CLAMD_DISABLE_CONCURRENT_RELOAD'].nil? %>
+ConcurrentDatabaseReload  no
+<% end %>


### PR DESCRIPTION
Add support for a new environment variable that allows users to disable the `ConcurrentDatabaseReload` feature of clamd.
When disabled, this feature allows for lower RAM requirements but blocks scans whenever a database reload occurs.

Fixes #3