### PR TITLE
Only start ClamAV in the specified process types

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ ClamAV do it through the local unix socket on which clamd is listening
 3. Make sure your start the other processes that will communicate with ClamAV.
    You may need a `Procfile` to do this.
 
-4. Trigger your deployment.
+4. Specify the name of the process type(s) for which you want ClamAV to run
+   using the [`CLAMAV_PROCESS_TYPES` environment variable](#CLAMAV_PROCESS_TYPES).
+
+5. Trigger your deployment.
 
 ### Deployment workflow
 
@@ -58,10 +61,10 @@ The default configuration ensures that:
 
 - `clamd` runs in background.
 - `clamd` listens on a local unix socket (`/app/clamav/run/clamd.sock`).
-- `freshclam` runs in background, checking for updates 12 times a day,
-  unless specified otherwise (see [Environment](#environment) below).
+- `freshclam` runs in background, checking for updates 12 times a day.
 - `freshclam` uses the default `database.clamav.net` mirror, unless
-  specified otherwise (see [Environment](#environment) below).
+  specified otherwise (see [`CLAMD_DATABASE_MIRROR`](#CLAMD_DATABASE_MIRROR)
+  below).
 
 #### Memory consumption
 
@@ -92,9 +95,18 @@ deployment:
 
 Version of ClamAV to use.\
 Please see [https://www.clamav.net/downloads](https://www.clamav.net/downloads)
-For a list of available version.\
+for a list of available version.\
 We usually advise to use the latest version available.\
 Default is set in [DEFAULT_VERSIONS file](DEFAULT_VERSIONS)
+
+#### `CLAMAV_PROCESS_TYPES`
+
+A comma separated list of process type names for which ClamAV is started.\
+Please read [our documentation about the `Procfile`](https://doc.scalingo.com/platform/app/procfile)
+to know more about process types.\
+Special process types such as `web`, `tcp`, `postdeploy` and `one-off` are
+valid.\
+Defaults to `web`
 
 #### `CLAMD_DATABASE_MIRROR`
 

--- a/files/profile.d/010-clamav.sh
+++ b/files/profile.d/010-clamav.sh
@@ -10,7 +10,8 @@ export LD_LIBRARY_PATH
 CLAMAV_START=1
 
 # Get the process type name we're running in:
-current_process_type="$( echo "${CONTAINER}" | cut -d'-' -f1 )"
+# We must support "one-off" as a valid process type name, hence using rev:
+current_process_type="$( echo "${CONTAINER}" | rev | cut -d'-' -f2- | rev )"
 
 # Create the process_types array from CLAMAV_PROCESS_TYPES:
 IFS=', ' read -r -a process_types <<< "${CLAMAV_PROCESS_TYPES:-"web"}"

--- a/files/profile.d/010-clamav.sh
+++ b/files/profile.d/010-clamav.sh
@@ -5,3 +5,22 @@ export PATH
 
 LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${HOME}/clamav/lib"
 export LD_LIBRARY_PATH
+
+# Whether we should start ClamAV or not:
+CLAMAV_START=1
+
+# Get the process type name we're running in:
+current_process_type="$( echo "${CONTAINER}" | cut -d'-' -f1 )"
+
+# Create the process_types array from CLAMAV_PROCESS_TYPES:
+IFS=', ' read -r -a process_types <<< "${CLAMAV_PROCESS_TYPES:-"web"}"
+
+# Check if we are in a process type for which we want to start ClamAV:
+for p in "${process_types[@]}"; do
+	if [ "${p}" == "${current_process_type}" ]; then
+		CLAMAV_START=0
+		break
+	fi
+done
+
+export CLAMAV_START

--- a/files/profile.d/020-clamd.sh
+++ b/files/profile.d/020-clamd.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-# Starts clamd daemon unless CLAMD_DISABLE_DAEMON is set.
+# Starts clamd daemon only if:
+# - we are running in the appropriate process type,
+# - AND if CLAMD_DISABLE_DAEMON is unset.
 
 start_clamd() {
 	clamd --config-file="${HOME}/clamav/conf/clamd.conf"
@@ -20,7 +22,8 @@ ensure_clamd() {
 	done &
 }
 
-if [ -z "${CLAMD_DISABLE_DAEMON}" ]
-then
+# Only start ClamAV if the conditions are OK
+# `CLAMAV_START` is computed in 010-clamav.sh
+if [ -z "${CLAMD_DISABLE_DAEMON}" ] && [ "${CLAMAV_START}" -eq 0 ]; then
 	ensure_clamd
 fi

--- a/files/profile.d/030-freshclam.sh
+++ b/files/profile.d/030-freshclam.sh
@@ -23,8 +23,9 @@ ensure_freshclam() {
     done &
 }
 
-if [ -z "${FRESHCLAM_DISABLE_DAEMON}" ]
-then
+# Only start freshcalm if the conditions are OK
+# `CLAMAV_START` is computed in 010-clamav.sh
+if [ -z "${FRESHCLAM_DISABLE_DAEMON}" ] && [ "${CLAMAV_START}" -eq 0 ]; then
 	(
         # Wait a random amount of time to make sure instances DO NOT start
         # freshclam at the same time.


### PR DESCRIPTION
Add support for a new environment variable named `CLAMAV_PROCESS_TYPES` that allows to specify the process type names for which ClamAV is started.

Fix #12 